### PR TITLE
fix: Use propNames.tags.legth with timeRec.tags.length

### DIFF
--- a/src/next-nanika.ts
+++ b/src/next-nanika.ts
@@ -239,9 +239,15 @@ export namespace NextNanika {
                 }
               }
             }
-            for (let idx = 0; idx < timeRec.tags.length; idx++) {
-              params.properties[opts.propNames.tags[idx]] = {
-                multi_select: timeRec.tags[idx].map((tag) => ({ name: tag }))
+            for (
+              let idx = 0;
+              idx < timeRec.tags.length && opts.propNames.tags.length;
+              idx++
+            ) {
+              if (Array.isArray(timeRec.tags[idx])) {
+                params.properties[opts.propNames.tags[idx]] = {
+                  multi_select: timeRec.tags[idx].map((tag) => ({ name: tag }))
+                }
               }
             }
             if (timeRec.icon) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -188,6 +188,12 @@ export class GatherTimeRecs {
       const recName = rec.props?.[this.propNames.name]
       const recTime = rec.props?.[this.propNames.time]
       const recTags = this.propNames.tags.map((tags) => rec.props?.[tags])
+      const l = recTags.length - tags.length
+      let ttags = tags
+      if (l > 0) {
+        // tags が少ない場合は `[]` を追加
+        ttags = tags.concat(Array(l).fill([]))
+      }
       return (
         recName === name &&
         (recTime as any).start === start &&
@@ -195,8 +201,8 @@ export class GatherTimeRecs {
         recTags.every(
           (recTag, index) =>
             Array.isArray(recTag) &&
-            recTag.length === tags[index].length &&
-            recTag.every((tag, tagIndex) => tag === tags[index][tagIndex])
+            recTag.length === ttags[index].length &&
+            recTag.every((tag, tagIndex) => tag === ttags[index][tagIndex])
         )
       )
     })


### PR DESCRIPTION
入力データで定義されている配列をそのまま適用すると、指定されている
名前の個数を超えることがある。 よって、指定された名前の個数を超えない
ように修正する。
